### PR TITLE
Optimization in Cnf solves the problem of huge redundancy

### DIFF
--- a/satispy/cnf.py
+++ b/satispy/cnf.py
@@ -1,3 +1,5 @@
+cnfClass = None
+
 class Variable(object):
     def __init__(self, name, inverted=False):
         self.name = name
@@ -9,23 +11,23 @@ class Variable(object):
         return v
 
     def __and__(self, other):
-        c = Cnf.create_from(self)
+        c = cnfClass.create_from(self)
         return c & other
 
     def __or__(self, other):
-        c = Cnf.create_from(self)
+        c = cnfClass.create_from(self)
         return c | other
 
     def __xor__(self, other):
-        c = Cnf.create_from(self)
+        c = cnfClass.create_from(self)
         return c ^ other
 
     def __rshift__(self, other): # implies
-        c = Cnf.create_from(self)
+        c = cnfClass.create_from(self)
         return -c | other
 
     def __str__(self):
-        return ("-" if self.inverted else "") + self.name
+        return ("-" if self.inverted else "") + str(self.name)
 
     def __eq__(self, other):
         return self.name == other.name and self.inverted == other.inverted
@@ -40,6 +42,108 @@ class Variable(object):
             return -1
         else:
             return 1
+
+class NaiveCnf(object):
+    def __init__(self):
+        self.dis = []
+
+    @classmethod
+    def create_from(cls, x):
+        if isinstance(x, Variable):
+            cnf = NaiveCnf()
+            cnf.dis = [frozenset([x])]
+            return cnf
+        elif isinstance(x, cls):
+            return x
+        else:
+            raise Exception("Could not create a Cnf object from %s" % str(type(x)))
+
+    def __and__(self, other):
+        other = NaiveCnf.create_from(other)
+        result = NaiveCnf()
+        result.dis = self.dis + other.dis
+        return result
+
+    def __or__(self, other):
+        other = NaiveCnf.create_from(other)
+
+        if len(self.dis) > 0 and len(other.dis) > 0:
+            new_dis = []
+            for d1, d2 in [(d1,d2) for d1 in self.dis for d2 in other.dis]:
+                d3 = d1 | d2
+                new_dis.append(d3)
+        elif len(self.dis) == 0:
+            new_dis = other.dis
+        else:
+            new_dis = self.dis
+
+        c = NaiveCnf()
+        c.dis = new_dis
+        return c
+
+    def __xor__(self, other):
+        return (self | other) & (-self | -other)
+
+    def __neg__(self):
+        cnfs = []
+
+        for d in self.dis:
+            c = NaiveCnf()
+            for v in d:
+                c.dis.append(frozenset([-v]))
+            cnfs.append(c)
+
+        ret = NaiveCnf()
+        for cnf in cnfs:
+            ret |= cnf
+
+        return ret
+
+    def __rshift__(self, other): # implies
+        return -self | other
+
+    def __str__(self):
+        ret = []
+        for d in self.dis:
+            ret.append(" | ".join(map(str,d)))
+        return "(" + ") & (".join(ret) + ")"
+
+    def __eq__(self, other):
+        return self.dis == other.dis
+
+    def __hash__(self):
+        return hash(self.dis)
+
+def reduceCnf(cnf):
+    """
+    I just found a remarkably large bug in my SAT solver and found an 
+    interesting solution.
+    Remove all b | -b
+    (-b | b) & (b | -a) & (-b | a) & (a | -a)
+    becomes 
+    (b | -a) & (-b | a)
+
+    Remove all (-e) & (-e)
+    (-e | a) & (-e | a) & (-e | a) & (-e | a)
+    becomes
+    (-e | a)
+    (-b | b | c) becomes nothing, not (c)
+    """
+    output = Cnf()
+    for x in cnf.dis:
+        dont_add = False
+        for y in x:
+            for z in x:
+                if z == -y:
+                    dont_add = True
+                    break
+            if dont_add: break
+        if dont_add: continue
+        # TODO: Is this necessary anymore? Probably not. Do statistical analysis.
+        if x not in output.dis:
+            output.dis.append(x)
+    return output
+#end def reduceCnf(cnf)
 
 class Cnf(object):
     def __init__(self):
@@ -69,7 +173,8 @@ class Cnf(object):
             new_dis = []
             for d1, d2 in [(d1,d2) for d1 in self.dis for d2 in other.dis]:
                 d3 = d1 | d2
-                new_dis.append(d3)
+                if d3 not in new_dis:
+                    new_dis.append(d3)
         elif len(self.dis) == 0:
             new_dis = other.dis
         else:
@@ -77,10 +182,10 @@ class Cnf(object):
 
         c = Cnf()
         c.dis = new_dis
-        return c
+        return reduceCnf(c)
 
     def __xor__(self, other):
-        return (self | other) & (-self | -other)
+        return reduceCnf((self | other) & (-self | -other))
 
     def __neg__(self):
         cnfs = []
@@ -89,9 +194,11 @@ class Cnf(object):
             c = Cnf()
             for v in d:
                 c.dis.append(frozenset([-v]))
-            cnfs.append(c)
+            x = reduceCnf(c)
+            if x not in cnfs:
+                cnfs.append(x)
 
-        ret = cnfs.pop()
+        ret = Cnf()
         for cnf in cnfs:
             ret |= cnf
 
@@ -111,3 +218,6 @@ class Cnf(object):
 
     def __hash__(self):
         return hash(self.dis)
+
+# Change this to NaiveCnf if you want.
+cnfClass = Cnf


### PR DESCRIPTION
[Writeup](https://www.altsci.com/concepts/page.php?s=sat&p=1)
When working with very simple equations like the below, satispy will use excessive memory holding unnecessary statements.
For example:
```python
    import satispy
    a = satispy.Variable('a')
    b = satispy.Variable('b')
    c = satispy.Variable('c')
    e = satispy.Variable('e')
    d = -((((a ^ b) & c) ^ a) ^ e)
```
This patch fixes that problem. The function reduceCnf describes what it does, removing any clause with (a | -a).

The class NaiveCnf preserves the previous functionality for testing and uses that require optimization be turned off.