### PR TITLE
Bugfix: do not use global varmap in Solution; + run minisat on Windows

### DIFF
--- a/satispy/solution.py
+++ b/satispy/solution.py
@@ -1,7 +1,9 @@
 class Solution(object):
-    def __init__(self, success=False, error=False, varmap={}):
+    def __init__(self, success=False, error=False, varmap=None):
         self.success = success
         self.error = error
+        if varmap is None:
+            varmap = {}
         self.varmap = varmap
 
     def __getitem__(self, i):

--- a/satispy/solver/minisat.py
+++ b/satispy/solver/minisat.py
@@ -2,11 +2,13 @@ from satispy.io import DimacsCnf
 from satispy import Variable
 from satispy import Solution
 
+import sys
 from subprocess import call
 from tempfile import NamedTemporaryFile
 
 class Minisat(object):
-    COMMAND = 'minisat %s %s > /dev/null'
+    COMMAND = 'minisat %s %s > ' + \
+        ('NUL' if sys.platform == 'win32' else '/dev/null')
 
     def __init__(self, command=COMMAND):
         self.command = command

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ from setuptools import setup
 
 setup(
     name='satispy',
-    version='1.0a5',
+    version='1.0a6',
     description='An interface to SAT solver tools (like minisat)',
     author='FÁBIÁN Tamás László',
     author_email='giganetom@gmail.com',
     url='https://github.com/netom/satispy/',
-    download_url='https://github.com/netom/satispy/tarball/1.0a5#egg=satispy-1.0a5',
+    download_url='https://github.com/netom/satispy/tarball/1.0a6#egg=satispy-1.0a6',
     license='BSD License',
     platforms='OS Independent',
     packages=['satispy', 'satispy.io', 'satispy.solver'],


### PR DESCRIPTION
Summary of changes:
   * Use a separate instance of the `varmap` dictionary for each instance of the `Solution` object
   * use `NUL` instead of `/dev/null` when running minisat on Windows
   * bump up the package version to `1.0a6` 