### PR TITLE
Added timeout

### DIFF
--- a/satispy/solver/minisat.py
+++ b/satispy/solver/minisat.py
@@ -4,15 +4,18 @@ from satispy import Variable
 from satispy import Solution
 
 import sys
-from subprocess import call
+import os
+from subprocess import Popen, TimeoutExpired
 from tempfile import NamedTemporaryFile
+from signal import SIGTERM
 
 class Minisat(object):
     COMMAND = 'minisat %s %s > ' + \
         ('NUL' if sys.platform == 'win32' else '/dev/null')
 
-    def __init__(self, command=COMMAND):
+    def __init__(self, command=COMMAND, timeout=None):
         self.command = command
+        self.timeout = timeout
 
     def solve(self, cnf):
         s = Solution()
@@ -24,11 +27,18 @@ class Minisat(object):
         infile.write(io.tostring(cnf))
         infile.flush()
 
-        ret = call(self.command % (infile.name, outfile.name), shell=True)
+        try:
+            ret = Popen(self.command % (infile.name, outfile.name), shell=True,
+                        start_new_session=True)
+            ret.wait(timeout=self.timeout)
+        except TimeoutExpired as e:
+            print(e)
+            os.killpg(os.getpgid(ret.pid), SIGTERM)
+            raise e
 
         infile.close()
 
-        if ret != 10:
+        if ret.returncode != 10:
             return s
 
         s.success = True


### PR DESCRIPTION
I added a timeout to the Minisat class which can be optionally provided to kill the SAT-solving process after a specified time. In this case, a subprocess.TimeoutExpired Exception is thrown by the subprocess class which can be caught by the user of the library.